### PR TITLE
JIT Bindings for PyRoFFI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,15 +201,24 @@ if(CRICKET_BUILD_PYTHON)
     CPMAddPackage("gh:wjakob/nanobind#9a25aed8a7edfe60ef9ad1c911e57667bc4916c4")
   endif()
 
+  set(_cricket_python_sources src/bindings/python.cc)
+  if(CRICKET_BUILD_JIT)
+    list(APPEND _cricket_python_sources src/bindings/jit.cc)
+  endif()
+
   nanobind_add_module(_core_ext
       NB_STATIC
       STABLE_ABI
-      src/bindings/python.cc
+      ${_cricket_python_sources}
   )
   target_link_libraries(_core_ext PRIVATE cricket::cricket)
   target_include_directories(_core_ext PRIVATE
       third_party/nanobind_json/include
   )
+  if(CRICKET_BUILD_JIT)
+    target_link_libraries(_core_ext PRIVATE cricket::jit)
+    target_compile_definitions(_core_ext PRIVATE CRICKET_WITH_JIT)
+  endif()
 endif()
 
 if(CRICKET_BUILD_PYTHON)

--- a/src/bindings/jit.cc
+++ b/src/bindings/jit.cc
@@ -1,0 +1,196 @@
+// Python bindings for cricket's runtime JIT (LLVM ORC) so callers can compile a
+// C++ translation unit at runtime and pull out function pointers — used by
+// pyroffi to JIT-compile a robot-specialised VAMP collision checker and hand its
+// XLA FFI handler to JAX.
+//
+// Kept deliberately small: a single `JitSession` wrapper that owns a clang
+// front-end, an LLJIT, and an on-disk object cache.  `add_source` compiles +
+// links a TU; `handler_capsule` looks up an `extern "C" void *getter()` symbol,
+// calls it, and returns the resulting handler pointer wrapped in a PyCapsule
+// suitable for `jax.ffi.register_ffi_target`.
+
+#include <cricket/jit/compiler.hh>
+#include <cricket/jit/object_cache.hh>
+#include <cricket/jit/session.hh>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/filesystem.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
+#include <llvm/Support/Error.h>
+
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+namespace
+{
+    // A niladic getter emitted (with C linkage) by the per-robot translation
+    // unit; returns the address of an XLA FFI custom-call handler.
+    using HandlerGetter = void *(*)();
+
+    class PyJitSession
+    {
+    public:
+        explicit PyJitSession(const std::optional<std::filesystem::path> &cache_dir)
+        {
+            const auto dir = cache_dir.value_or(cricket::jit::default_cache_dir());
+            std::filesystem::create_directories(dir);
+            cache_ = std::make_shared<cricket::jit::DiskObjectCache>(dir);
+            session_ = std::make_unique<cricket::jit::JitSession>(cache_);
+        }
+
+        // Fast path: if an object compiled for `module_id` is already on disk,
+        // link it directly and skip the clang front-end entirely.  Returns true
+        // on a cache hit.
+        auto try_load_cached(const std::string &module_id) -> bool
+        {
+            auto obj = cache_->load_object(module_id);
+            if (not obj)
+            {
+                return false;
+            }
+            if (auto err = session_->add_object_file(std::move(obj)))
+            {
+                throw std::runtime_error(
+                    "cricket.jit: add_object_file failed: " + llvm::toString(std::move(err)));
+            }
+            return true;
+        }
+
+        auto add_source(const std::string &source, const cricket::jit::CompileOptions &opts) -> void
+        {
+            auto tsm = compiler_.compile(source, opts);
+            if (auto err = session_->add_module(std::move(tsm)))
+            {
+                throw std::runtime_error(
+                    "cricket.jit: add_module failed: " + llvm::toString(std::move(err)));
+            }
+        }
+
+        auto add_external_symbol(const std::string &name, std::uintptr_t addr) -> void
+        {
+            if (auto err = session_->add_external_symbol(name, reinterpret_cast<void *>(addr)))
+            {
+                throw std::runtime_error(
+                    "cricket.jit: add_external_symbol failed: " + llvm::toString(std::move(err)));
+            }
+        }
+
+        auto lookup_address(const std::string &symbol) -> std::uintptr_t
+        {
+            auto addr = session_->lookup(symbol);
+            if (not addr)
+            {
+                throw std::runtime_error(
+                    "cricket.jit: lookup('" + symbol + "') failed: " + llvm::toString(addr.takeError()));
+            }
+            return addr->getValue();
+        }
+
+        // Look up a `void *getter()` symbol, call it, and wrap the returned
+        // handler pointer in a PyCapsule for jax.ffi.register_ffi_target.
+        auto handler_capsule(const std::string &getter_symbol) -> nb::capsule
+        {
+            auto fn = session_->lookup_fn<void *()>(getter_symbol);
+            if (not fn)
+            {
+                throw std::runtime_error(
+                    "cricket.jit: lookup_fn('" + getter_symbol +
+                    "') failed: " + llvm::toString(fn.takeError()));
+            }
+            void *handler = (*fn.get())();
+            if (handler == nullptr)
+            {
+                throw std::runtime_error("cricket.jit: handler getter '" + getter_symbol + "' returned null");
+            }
+            return nb::capsule(handler);
+        }
+
+        auto cache_dir() const -> std::filesystem::path
+        {
+            return cache_->directory();
+        }
+
+    private:
+        std::shared_ptr<cricket::jit::DiskObjectCache> cache_;
+        std::unique_ptr<cricket::jit::JitSession> session_;
+        cricket::jit::ClangCompiler compiler_;
+    };
+}  // namespace
+
+namespace cricket
+{
+    void init_jit(nb::module_ &m)
+    {
+        auto jit = m.def_submodule("jit", "Runtime JIT compilation (LLVM ORC).");
+
+        nb::class_<jit::CompileOptions>(jit, "CompileOptions")
+            .def(nb::init<>())
+            .def_rw("std_flag", &jit::CompileOptions::std_flag)
+            .def_rw("opt_flag", &jit::CompileOptions::opt_flag)
+            .def_rw("default_flags", &jit::CompileOptions::default_flags)
+            .def_rw("include_dirs", &jit::CompileOptions::include_dirs)
+            .def_rw("system_include_dirs", &jit::CompileOptions::system_include_dirs)
+            .def_rw("defines", &jit::CompileOptions::defines)
+            .def_rw("extra_flags", &jit::CompileOptions::extra_flags)
+            .def_rw("module_id", &jit::CompileOptions::module_id);
+
+        nb::class_<PyJitSession>(jit, "JitSession")
+            .def(
+                nb::init<const std::optional<std::filesystem::path> &>(),
+                "cache_dir"_a = nb::none(),
+                "Create a JIT session backed by an on-disk object cache.")
+            .def(
+                "try_load_cached",
+                &PyJitSession::try_load_cached,
+                "module_id"_a,
+                "Link a previously-cached object for module_id, skipping clang. "
+                "Returns True on a cache hit.")
+            .def(
+                "add_source",
+                &PyJitSession::add_source,
+                "source"_a,
+                "options"_a,
+                "Compile a C++ translation unit and add it to the session.")
+            .def(
+                "add_external_symbol",
+                &PyJitSession::add_external_symbol,
+                "name"_a,
+                "address"_a,
+                "Define an absolute external symbol (address as an integer).")
+            .def(
+                "lookup_address",
+                &PyJitSession::lookup_address,
+                "symbol"_a,
+                "Return the JIT address of a symbol as an integer.")
+            .def(
+                "handler_capsule",
+                &PyJitSession::handler_capsule,
+                "getter_symbol"_a,
+                "Call an `extern \"C\" void *getter()` symbol and return its result "
+                "wrapped in a PyCapsule for jax.ffi.register_ffi_target.")
+            .def_prop_ro("cache_dir", &PyJitSession::cache_dir);
+
+        jit.def(
+            "hash_source",
+            [](const std::string &source, const jit::CompileOptions &opts)
+            { return jit::hash_source(source, opts); },
+            "source"_a,
+            "options"_a,
+            "Stable content hash of (source, options) for cache keying.");
+
+        jit.def(
+            "default_cache_dir",
+            []() { return jit::default_cache_dir(); },
+            "Default on-disk object cache directory.");
+    }
+}  // namespace cricket

--- a/src/bindings/jit.cc
+++ b/src/bindings/jit.cc
@@ -1,13 +1,12 @@
-// Python bindings for cricket's runtime JIT (LLVM ORC) so callers can compile a
-// C++ translation unit at runtime and pull out function pointers — used by
-// pyroffi to JIT-compile a robot-specialised VAMP collision checker and hand its
-// XLA FFI handler to JAX.
+// Python bindings for cricket's runtime JIT (LLVM ORC) so python can compile a
+// C++ translation unit at runtime/pull out function pointers.  The API exposes generic 
+// compile / link / symbol-lookup primitives and knows nothing about any particular caller.
 //
-// Kept deliberately small: a single `JitSession` wrapper that owns a clang
+// The wrapper is lightweight, a single `JitSession` wrapper that owns a clang
 // front-end, an LLJIT, and an on-disk object cache.  `add_source` compiles +
 // links a TU; `handler_capsule` looks up an `extern "C" void *getter()` symbol,
-// calls it, and returns the resulting handler pointer wrapped in a PyCapsule
-// suitable for `jax.ffi.register_ffi_target`.
+// calls it, and returns the resulting pointer wrapped in a PyCapsule.  That
+// capsule is consumable by a C-pointer FFI boundary like PyRoFFI
 
 #include <cricket/jit/compiler.hh>
 #include <cricket/jit/object_cache.hh>
@@ -33,14 +32,10 @@ using namespace nb::literals;
 
 namespace
 {
-    // A niladic getter emitted (with C linkage) by the per-robot translation
-    // unit; returns the address of an XLA FFI custom-call handler.
-    using HandlerGetter = void *(*)();
-
-    class PyJitSession
+    class CricketJitSession
     {
     public:
-        explicit PyJitSession(const std::optional<std::filesystem::path> &cache_dir)
+        explicit CricketJitSession(const std::optional<std::filesystem::path> &cache_dir)
         {
             const auto dir = cache_dir.value_or(cricket::jit::default_cache_dir());
             std::filesystem::create_directories(dir);
@@ -96,8 +91,8 @@ namespace
             return addr->getValue();
         }
 
-        // Look up a `void *getter()` symbol, call it, and wrap the returned
-        // handler pointer in a PyCapsule for jax.ffi.register_ffi_target.
+        // Look up an `extern "C" void *getter()` symbol, call it, and wrap the
+        // returned pointer in a PyCapsule.
         auto handler_capsule(const std::string &getter_symbol) -> nb::capsule
         {
             auto fn = session_->lookup_fn<void *()>(getter_symbol);
@@ -144,41 +139,41 @@ namespace cricket
             .def_rw("extra_flags", &jit::CompileOptions::extra_flags)
             .def_rw("module_id", &jit::CompileOptions::module_id);
 
-        nb::class_<PyJitSession>(jit, "JitSession")
+        nb::class_<CricketJitSession>(jit, "JitSession")
             .def(
                 nb::init<const std::optional<std::filesystem::path> &>(),
                 "cache_dir"_a = nb::none(),
                 "Create a JIT session backed by an on-disk object cache.")
             .def(
                 "try_load_cached",
-                &PyJitSession::try_load_cached,
+                &CricketJitSession::try_load_cached,
                 "module_id"_a,
                 "Link a previously-cached object for module_id, skipping clang. "
                 "Returns True on a cache hit.")
             .def(
                 "add_source",
-                &PyJitSession::add_source,
+                &CricketJitSession::add_source,
                 "source"_a,
                 "options"_a,
                 "Compile a C++ translation unit and add it to the session.")
             .def(
                 "add_external_symbol",
-                &PyJitSession::add_external_symbol,
+                &CricketJitSession::add_external_symbol,
                 "name"_a,
                 "address"_a,
                 "Define an absolute external symbol (address as an integer).")
             .def(
                 "lookup_address",
-                &PyJitSession::lookup_address,
+                &CricketJitSession::lookup_address,
                 "symbol"_a,
                 "Return the JIT address of a symbol as an integer.")
             .def(
                 "handler_capsule",
-                &PyJitSession::handler_capsule,
+                &CricketJitSession::handler_capsule,
                 "getter_symbol"_a,
                 "Call an `extern \"C\" void *getter()` symbol and return its result "
-                "wrapped in a PyCapsule for jax.ffi.register_ffi_target.")
-            .def_prop_ro("cache_dir", &PyJitSession::cache_dir);
+                "wrapped in a PyCapsule (e.g. for jax.ffi.register_ffi_target).")
+            .def_prop_ro("cache_dir", &CricketJitSession::cache_dir);
 
         jit.def(
             "hash_source",

--- a/src/bindings/python.cc
+++ b/src/bindings/python.cc
@@ -20,9 +20,20 @@
 namespace nb = nanobind;
 using namespace nb::literals;
 
+#ifdef CRICKET_WITH_JIT
+namespace cricket
+{
+    void init_jit(nanobind::module_ &m);
+}
+#endif
+
 NB_MODULE(_core_ext, m)
 {
     m.doc() = "Cricket: tracing compilation for spherized robot kinematics.";
+
+#ifdef CRICKET_WITH_JIT
+    cricket::init_jit(m);
+#endif
 
     nb::class_<cricket::RobotInfo>(m, "RobotInfo")
         .def(


### PR DESCRIPTION
I added a light JIT session binding layer for plugging into PyRoFFI. List of changes:
- Added jit.cc. This file builds on python.cc and once the robot source is generated, hands off the C pointer to python so it can repeatedly access the JIT compiled collision checking binaries for edge validation in PyRoFFI
- Updated CMakeLists nanobind build with a list of python-related files instead of hardcoding the python.cc file
- Updated python.cc with headers to decide whether to build the JIT or not


Usage in PyRoFFI (_vamp_collision.py):
```
# Codegen: URDF -> vamp::robots::<Robot> source.
        gen = cricket.generate_robot_source(
            cricket.GenOptions(
                urdf=urdf_path,
                srdf=srdf_path,
                end_effector=end_effector,
                data={"name": robot_name, "resolution": int(resolution)},
            )
        )
``` 

```
# materializing and saving the header translation unit, saved for future calls to avoid recompilation if the robot is the same
        digest = hashlib.sha1()
        digest.update(gen.source.encode())
        digest.update(_FFI_HEADER.read_bytes())
        digest.update(_TU_TEMPLATE.read_bytes())
        src_hash = digest.hexdigest()[:16]
        work_dir = Path(cache_dir) if cache_dir is not None else Path(jit.default_cache_dir())
        work_dir.mkdir(parents=True, exist_ok=True)
        header_path = work_dir / f"vamp_robot_{robot_token}_{src_hash}.hh"
        if not header_path.exists():
            header_path.write_text(gen.source)

        # 3. Build the per-robot translation unit from the template.
        tu_source = (
            _TU_TEMPLATE.read_text()
            .replace("@ROBOT_HEADER@", str(header_path))
            .replace("@FFI_HEADER@", str(_FFI_HEADER))
            .replace("@ROBOT_TYPE@", f"vamp::robots::{robot_type_name}")
            .replace("@ROBOT_NAME@", robot_token)
        )
```

```
# JIT Session Initialization (new code used)

        opts = jit.CompileOptions()
        opts.std_flag = "-std=c++17"
        opts.opt_flag = "-O3"
        dirs = _default_include_dirs()
        if include_dirs:
            dirs.extend(include_dirs)
        opts.include_dirs = dirs
        opts.extra_flags = extra_flags or ["-march=native", "-fopenmp"]
        opts.module_id = f"vamp_{robot_token}_{src_hash}"

        # Cache the (source, opts) hash so re-registration is skipped.
        self._key = jit.hash_source(tu_source, opts)
        self._configs_target = f"vamp_configs_{robot_token}_{src_hash}"
        self._edges_target = f"vamp_edges_{robot_token}_{src_hash}"

        if self._key not in _REGISTERED:
            _preload_runtime_libs()
            session = jit.JitSession(work_dir)
            # Reuse a previously JIT-compiled binary for this robot if present,
            # skipping the (expensive) clang front-end; else compile + cache it.
            if not session.try_load_cached(opts.module_id):
                session.add_source(tu_source, opts)
            jax.ffi.register_ffi_target(
                self._configs_target,
                session.handler_capsule("pyroffi_get_validate_configs"),
                platform="cpu",
            )
            jax.ffi.register_ffi_target(
                self._edges_target,
                session.handler_capsule("pyroffi_get_validate_edges"),
                platform="cpu",
            )
            # Keep the session alive for the process lifetime: the JIT-owned code
            # must outlive every FFI call into it.
            _REGISTERED[self._key] = self._configs_target
            self._session = session
        else:
            self._session = None
```