### PR TITLE
feat: mobile radius bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ In addition to the specified input fields from the configuration file, the scrip
 - `end_effector_index`: frame index of end-effector.
 - `min_radius`: minimum sphere radius on robot.
 - `max_radius`: maximum sphere radius on robot.
+- `min_radius_mobile`: minimum sphere radius among mobile (non-fixed) spheres, i.e. spheres whose kinematic chain includes at least one moving joint.
+- `max_radius_mobile`: maximum sphere radius among mobile (non-fixed) spheres.
+- `min_bounding_radius_mobile`: minimum radius among the per-link bounding spheres (used in the collision-checking hierarchy) belonging to mobile (non-fixed) links.
+- `max_bounding_radius_mobile`: maximum radius among the per-link bounding spheres belonging to mobile (non-fixed) links.
 - `joint_names`: name of joint corresponding to each DoF.
 - `link_names`: name of frame corresponding to index.
 - `per_link_spheres`: for each frame, the indices of the spheres associated with that frame.

--- a/include/cricket/robot_info.hh
+++ b/include/cricket/robot_info.hh
@@ -83,6 +83,10 @@ namespace cricket
 
         float min_radius{std::numeric_limits<float>::max()};
         float max_radius{std::numeric_limits<float>::min()};
+        float min_radius_mobile{std::numeric_limits<float>::max()};
+        float max_radius_mobile{std::numeric_limits<float>::min()};
+        float min_bounding_radius_mobile{std::numeric_limits<float>::max()};
+        float max_bounding_radius_mobile{std::numeric_limits<float>::min()};
         std::vector<SphereInfo> spheres;
         std::map<std::size_t, SphereInfo> bounding_spheres;
         std::vector<std::size_t> links_with_geometry;

--- a/resources/templates/fk_template.hh
+++ b/resources/templates/fk_template.hh
@@ -16,6 +16,10 @@ struct {{name}}
     static constexpr std::size_t n_spheres = {{n_spheres}};
     static constexpr float min_radius = {{min_radius}};
     static constexpr float max_radius = {{max_radius}};
+    static constexpr float min_radius_mobile = {{min_radius_mobile}};
+    static constexpr float max_radius_mobile = {{max_radius_mobile}};
+    static constexpr float min_bounding_radius_mobile = {{min_bounding_radius_mobile}};
+    static constexpr float max_bounding_radius_mobile = {{max_bounding_radius_mobile}};
     static constexpr std::size_t resolution = {{resolution}};
     static constexpr bool euclidean = {{euclidean}};
 

--- a/resources/templates/fk_template.rs
+++ b/resources/templates/fk_template.rs
@@ -39,6 +39,10 @@ impl {{name}} {
 
     pub const MIN_RADIUS: f32 = {{min_radius}};
     pub const MAX_RADIUS: f32 = {{max_radius}};
+    pub const MIN_RADIUS_MOBILE: f32 = {{min_radius_mobile}};
+    pub const MAX_RADIUS_MOBILE: f32 = {{max_radius_mobile}};
+    pub const MIN_BOUNDING_RADIUS_MOBILE: f32 = {{min_bounding_radius_mobile}};
+    pub const MAX_BOUNDING_RADIUS_MOBILE: f32 = {{max_bounding_radius_mobile}};
 }
 
 const fn make_upper(lower: [f32; DIM], scale: [f32; DIM]) -> [f32; DIM] {

--- a/src/bindings/python.cc
+++ b/src/bindings/python.cc
@@ -51,6 +51,12 @@ NB_MODULE(_core_ext, m)
         .def_prop_ro("n_spheres", [](cricket::RobotInfo &r) { return r.spheres.size(); })
         .def_prop_ro("min_radius", [](cricket::RobotInfo &r) { return r.min_radius; })
         .def_prop_ro("max_radius", [](cricket::RobotInfo &r) { return r.max_radius; })
+        .def_prop_ro("min_radius_mobile", [](cricket::RobotInfo &r) { return r.min_radius_mobile; })
+        .def_prop_ro("max_radius_mobile", [](cricket::RobotInfo &r) { return r.max_radius_mobile; })
+        .def_prop_ro(
+            "min_bounding_radius_mobile", [](cricket::RobotInfo &r) { return r.min_bounding_radius_mobile; })
+        .def_prop_ro(
+            "max_bounding_radius_mobile", [](cricket::RobotInfo &r) { return r.max_bounding_radius_mobile; })
         .def_prop_ro("end_effector_name", [](cricket::RobotInfo &r) { return r.end_effector_name; })
         .def(
             "json",

--- a/src/robot_info.cc
+++ b/src/robot_info.cc
@@ -219,6 +219,10 @@ namespace cricket
         json["end_effector_index"] = end_effector_index;
         json["min_radius"] = min_radius;
         json["max_radius"] = max_radius;
+        json["min_radius_mobile"] = min_radius_mobile;
+        json["max_radius_mobile"] = max_radius_mobile;
+        json["min_bounding_radius_mobile"] = min_bounding_radius_mobile;
+        json["max_bounding_radius_mobile"] = max_bounding_radius_mobile;
         json["joint_names"] = dof_to_joint_names();
         json["allowed_link_pairs"] = allowed_link_pairs;
         json["per_link_spheres"] = per_link_spheres;
@@ -316,6 +320,14 @@ namespace cricket
 
                 min_radius = std::min(min_radius, info.radius);
                 max_radius = std::max(max_radius, info.radius);
+
+                // Joint index 0 is always "universe": spheres whose kinematic chain has no
+                // moving joint above it are rigidly fixed to the world and thus immobile.
+                if (info.parent_joint != 0)
+                {
+                    min_radius_mobile = std::min(min_radius_mobile, info.radius);
+                    max_radius_mobile = std::max(max_radius_mobile, info.radius);
+                }
             }
             else
             {
@@ -357,6 +369,12 @@ namespace cricket
                 bounding_sphere_index.emplace_back(bs);
                 links_with_geometry.emplace_back(i);
                 bs++;
+
+                if (info.parent_joint != 0)
+                {
+                    min_bounding_radius_mobile = std::min(min_bounding_radius_mobile, info.radius);
+                    max_bounding_radius_mobile = std::max(max_bounding_radius_mobile, info.radius);
+                }
             }
             else
             {


### PR DESCRIPTION
Emits fields for bounds of the radii of mobile spheres (which are not attached to the fixed link).